### PR TITLE
docs: Make various README.md files consistent.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,29 @@
 dcrutil
 =======
 
+[![Build Status](http://img.shields.io/travis/decred/dcrutil.svg)]
+(https://travis-ci.org/decred/dcrutil) [![Coverage Status]
+(http://img.shields.io/coveralls/decred/dcrutil.svg)]
+(https://coveralls.io/r/decred/dcrutil?branch=master) [![ISC License]
+(http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![GoDoc](http://img.shields.io/badge/godoc-reference-blue.svg)]
+(http://godoc.org/github.com/decred/dcrutil)
+
 Package dcrutil provides decred-specific convenience functions and types.
 A comprehensive suite of tests is provided to ensure proper functionality.  See
 `test_coverage.txt` for the gocov coverage report.  Alternatively, if you are
 running a POSIX OS, you can run the `cov_report.sh` script for a real-time
-report.  Package dcrutil is licensed under the liberal ISC license.
+report.
 
-This package was developed for dcrd, an alternative full-node implementation of
-Decred which is under active development by Company 0.  Although it was
-primarily written for dcrd, this package has intentionally been designed so it
-can be used as a standalone package for any projects needing the functionality
-provided.
+This package was developed for dcrd, a full-node implementation of Decred which
+is under active development by Company 0.  Although it was primarily written for
+dcrd, this package has intentionally been designed so it can be used as a
+standalone package for any projects needing the functionality provided.
 
-## Documentation
-
-[![GoDoc](https://godoc.org/github.com/decred/dcrutil?status.png)]
-(http://godoc.org/github.com/decred/dcrutil)
-
-Full `go doc` style documentation for the project can be viewed online without
-installing this package by using the GoDoc site here:
-http://godoc.org/github.com/decred/dcrutil
-
-You can also view the documentation locally once the package is installed with
-the `godoc` tool by running `godoc -http=":6060"` and pointing your browser to
-http://localhost:6060/pkg/github.com/decred/dcrutil
-
-## Installation
+## Installation and Updating
 
 ```bash
-$ go get github.com/decred/dcrutil
+$ go get -u github.com/decred/dcrutil
 ```
 
 ## License

--- a/base58/README.md
+++ b/base58/README.md
@@ -1,33 +1,22 @@
 base58
 ==========
 
-[![Build Status](https://travis-ci.org/decred/dcrutil.png?branch=master)]
-(https://travis-ci.org/decred/dcrutil)
+[![Build Status](http://img.shields.io/travis/decred/dcrutil.svg)]
+(https://travis-ci.org/decred/dcrutil) [![ISC License]
+(http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![GoDoc](https://godoc.org/github.com/decred/dcrutil/base58?status.png)]
+(http://godoc.org/github.com/decred/dcrutil/base58)
 
 Package base58 provides an API for encoding and decoding to and from the
 modified base58 encoding.  It also provides an API to do Base58Check encoding,
 as described [here](https://en.bitcoin.it/wiki/Base58Check_encoding).
 
 A comprehensive suite of tests is provided to ensure proper functionality.
-Package base58 is licensed under the copyfree ISC license.
 
-## Documentation
-
-[![GoDoc](https://godoc.org/github.com/decred/dcrutil/base58?status.png)]
-(http://godoc.org/github.com/decred/dcrutil/base58)
-
-Full `go doc` style documentation for the project can be viewed online without
-installing this package by using the GoDoc site here:
-http://godoc.org/github.com/decred/dcrutil/base58
-
-You can also view the documentation locally once the package is installed with
-the `godoc` tool by running `godoc -http=":6060"` and pointing your browser to
-http://localhost:6060/pkg/github.com/decred/dcrutil/base58
-
-## Installation
+## Installation and Updating
 
 ```bash
-$ go get github.com/decred/dcrutil/base58
+$ go get -u github.com/decred/dcrutil/base58
 ```
 
 ## Examples

--- a/bloom/README.md
+++ b/bloom/README.md
@@ -1,33 +1,23 @@
 bloom
 =====
 
-[![Build Status](https://travis-ci.org/decred/dcrutil.png?branch=master)]
-(https://travis-ci.org/decred/dcrutil)
+[![Build Status](http://img.shields.io/travis/decred/dcrutil.svg)]
+(https://travis-ci.org/decred/dcrutil) [![ISC License]
+(http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![GoDoc](http://img.shields.io/badge/godoc-reference-blue.svg)]
+(http://godoc.org/github.com/decred/dcrutil/bloom)
 
 Package bloom provides an API for dealing with decred-specific bloom filters.
 
 A comprehensive suite of tests is provided to ensure proper functionality.  See
 `test_coverage.txt` for the gocov coverage report.  Alternatively, if you are
 running a POSIX OS, you can run the `cov_report.sh` script for a real-time
-report.  Package coinset is licensed under the liberal ISC license.
+report.
 
-## Documentation
-
-[![GoDoc](https://godoc.org/github.com/decred/dcrutil/bloom?status.png)]
-(http://godoc.org/github.com/decred/dcrutil/bloom)
-
-Full `go doc` style documentation for the project can be viewed online without
-installing this package by using the GoDoc site here:
-http://godoc.org/github.com/decred/dcrutil/bloom
-
-You can also view the documentation locally once the package is installed with
-the `godoc` tool by running `godoc -http=":6060"` and pointing your browser to
-http://localhost:6060/pkg/github.com/decred/dcrutil/bloom
-
-## Installation
+## Installation and Updating
 
 ```bash
-$ go get github.com/decred/dcrutil/bloom
+$ go get -u github.com/decred/dcrutil/bloom
 ```
 
 ## Examples

--- a/coinset/README.md
+++ b/coinset/README.md
@@ -1,8 +1,11 @@
 coinset
 =======
 
-[![Build Status](https://travis-ci.org/decred/dcrutil.png?branch=master)]
-(https://travis-ci.org/decred/dcrutil)
+[![Build Status](http://img.shields.io/travis/decred/dcrutil.svg)]
+(https://travis-ci.org/decred/dcrutil) [![ISC License]
+(http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![GoDoc](http://img.shields.io/badge/godoc-reference-blue.svg)]
+(http://godoc.org/github.com/decred/dcrutil/coinset)
 
 Package coinset provides decred-specific convenience functions for selecting
 from and managing sets of unspent transaction outpoints (UTXOs).
@@ -10,25 +13,12 @@ from and managing sets of unspent transaction outpoints (UTXOs).
 A comprehensive suite of tests is provided to ensure proper functionality.  See
 `test_coverage.txt` for the gocov coverage report.  Alternatively, if you are
 running a POSIX OS, you can run the `cov_report.sh` script for a real-time
-report.  Package coinset is licensed under the liberal ISC license.
+report.
 
-## Documentation
-
-[![GoDoc](https://godoc.org/github.com/decred/dcrutil/coinset?status.png)]
-(http://godoc.org/github.com/decred/dcrutil/coinset)
-
-Full `go doc` style documentation for the project can be viewed online without
-installing this package by using the GoDoc site here:
-http://godoc.org/github.com/decred/dcrutil/coinset
-
-You can also view the documentation locally once the package is installed with
-the `godoc` tool by running `godoc -http=":6060"` and pointing your browser to
-http://localhost:6060/pkg/github.com/decred/dcrutil/coinset
-
-## Installation
+## Installation and Updating
 
 ```bash
-$ go get github.com/decred/dcrutil/coinset
+$ go get -u github.com/decred/dcrutil/coinset
 ```
 
 ## Usage

--- a/hdkeychain/README.md
+++ b/hdkeychain/README.md
@@ -1,8 +1,11 @@
 hdkeychain
 ==========
 
-[![Build Status](https://travis-ci.org/decred/dcrutil.png?branch=master)]
-(https://travis-ci.org/decred/dcrutil)
+[![Build Status](http://img.shields.io/travis/decred/dcrutil.svg)]
+(https://travis-ci.org/decred/dcrutil) [![ISC License]
+(http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![GoDoc](http://img.shields.io/badge/godoc-reference-blue.svg)]
+(http://godoc.org/github.com/decred/dcrutil/hdkeychain)
 
 Package hdkeychain provides an API for Decred hierarchical deterministic
 extended keys (based on BIP0032).
@@ -10,7 +13,7 @@ extended keys (based on BIP0032).
 A comprehensive suite of tests is provided to ensure proper functionality.  See
 `test_coverage.txt` for the gocov coverage report.  Alternatively, if you are
 running a POSIX OS, you can run the `cov_report.sh` script for a real-time
-report.  Package hdkeychain is licensed under the liberal ISC license.
+report.
 
 ## Feature Overview
 
@@ -35,23 +38,10 @@ report.  Package hdkeychain is licensed under the liberal ISC license.
 - Comprehensive test coverage including the BIP0032 test vectors
 - Benchmarks
 
-## Documentation
-
-[![GoDoc](https://godoc.org/github.com/decred/dcrutil/hdkeychain?status.png)]
-(http://godoc.org/github.com/decred/dcrutil/hdkeychain)
-
-Full `go doc` style documentation for the project can be viewed online without
-installing this package by using the GoDoc site here:
-http://godoc.org/github.com/decred/dcrutil/hdkeychain
-
-You can also view the documentation locally once the package is installed with
-the `godoc` tool by running `godoc -http=":6060"` and pointing your browser to
-http://localhost:6060/pkg/github.com/decred/dcrutil/hdkeychain
-
-## Installation
+## Installation and Updating
 
 ```bash
-$ go get github.com/decred/dcrutil/hdkeychain
+$ go get -u github.com/decred/dcrutil/hdkeychain
 ```
 
 ## Examples


### PR DESCRIPTION
Contains the following upstream commits:
- 5fd45e8085e53fa58c8b979762e45aa4e8879e7e
  - Reverted because txsort needs a decred-specific spec
- 98fd0a0661ca0cb393382e061735798dafa93ed0
  - Reverted because txsort needs a decred-specific spec
- e0e9257790367184e97012a52d174c3be8314b93
  - Reverted because txsort needs a decred-specific spec
- 0df67ee0646e5fb24d4d25cb0b58abc642cd80a9
  - Reverted because txsort needs a decred-specific spec
- d6989ebc716421498125f078e6c2b9846505c09e
  - Reverted because txsort needs a decred-specific spec
- e8bab6bc196dcb7e1c17c91b0ff9d50e76c797e3

As noted, the merge commit reverts all of the txsort-related commits in between.  It also modifies the paths in the `README` updates to decred-specific paths.
