### PR TITLE
bloom: Avoid a few unnecessary hash copies.

### DIFF
--- a/bloom/example_test.go
+++ b/bloom/example_test.go
@@ -38,7 +38,7 @@ func ExampleNewFilter() {
 	filter.AddShaHash(txHash)
 
 	// Show that the filter matches.
-	matches := filter.Matches(txHash.Bytes())
+	matches := filter.Matches(txHash[:])
 	fmt.Println("Filter Matches?:", matches)
 
 	// Output:

--- a/bloom/filter.go
+++ b/bloom/filter.go
@@ -1,5 +1,5 @@
-// Copyright (c) 2014 The btcsuite developers
-// Copyright (c) 2015 The Decred developers
+// Copyright (c) 2014-2016 The btcsuite developers
+// Copyright (c) 2015-2016 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -49,7 +49,7 @@ func NewFilter(elements, tweak uint32, fprate float64, flags wire.BloomUpdateTyp
 	if fprate > 1.0 {
 		fprate = 1.0
 	}
-	if fprate < 0 {
+	if fprate < 1e-9 {
 		fprate = 1e-9
 	}
 

--- a/bloom/filter.go
+++ b/bloom/filter.go
@@ -169,7 +169,7 @@ func (bf *Filter) Matches(data []byte) bool {
 func (bf *Filter) matchesOutPoint(outpoint *wire.OutPoint) bool {
 	// Serialize
 	var buf [chainhash.HashSize + 4]byte
-	copy(buf[:], outpoint.Hash.Bytes())
+	copy(buf[:], outpoint.Hash[:])
 	binary.LittleEndian.PutUint32(buf[chainhash.HashSize:], outpoint.Index)
 
 	return bf.matches(buf[:])
@@ -219,9 +219,9 @@ func (bf *Filter) Add(data []byte) {
 // AddShaHash adds the passed chainhash.Hash to the Filter.
 //
 // This function is safe for concurrent access.
-func (bf *Filter) AddShaHash(sha *chainhash.Hash) {
+func (bf *Filter) AddShaHash(hash *chainhash.Hash) {
 	bf.mtx.Lock()
-	bf.add(sha.Bytes())
+	bf.add(hash[:])
 	bf.mtx.Unlock()
 }
 
@@ -231,7 +231,7 @@ func (bf *Filter) AddShaHash(sha *chainhash.Hash) {
 func (bf *Filter) addOutPoint(outpoint *wire.OutPoint) {
 	// Serialize
 	var buf [chainhash.HashSize + 4]byte
-	copy(buf[:], outpoint.Hash.Bytes())
+	copy(buf[:], outpoint.Hash[:])
 	binary.LittleEndian.PutUint32(buf[chainhash.HashSize:], outpoint.Index)
 
 	bf.add(buf[:])
@@ -275,7 +275,7 @@ func (bf *Filter) maybeAddOutpoint(pkScrVer uint16, pkScript []byte,
 func (bf *Filter) matchTxAndUpdate(tx *dcrutil.Tx) bool {
 	// Check if the filter matches the hash of the transaction.
 	// This is useful for finding transactions when they appear in a block.
-	matched := bf.matches(tx.Sha().Bytes())
+	matched := bf.matches(tx.Sha()[:])
 
 	// Check if the filter matches any data elements in the public key
 	// scripts of any of the outputs.  When it does, add the outpoint that

--- a/bloom/filter_test.go
+++ b/bloom/filter_test.go
@@ -1,5 +1,5 @@
-// Copyright (c) 2013, 2014 The btcsuite developers
-// Copyright (c) 2015 The Decred developers
+// Copyright (c) 2013-2016 The btcsuite developers
+// Copyright (c) 2015-2016 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -94,6 +94,66 @@ func TestFilterInsert(t *testing.T) {
 		t.Errorf("TestFilterInsert failure: got %v want %v\n",
 			got.Bytes(), want)
 		return
+	}
+}
+
+// TestFilterFPRange checks that new filters made with out of range
+// false positive targets result in either max or min false positive rates.
+func TestFilterFPRange(t *testing.T) {
+	tests := []struct {
+		name   string
+		hash   string
+		want   string
+		filter *bloom.Filter
+	}{
+		{
+			name:   "fprates > 1 should be clipped at 1",
+			hash:   "02981fa052f0481dbc5868f4fc2166035a10f27a03cfd2de67326471df5bc041",
+			want:   "00000000000000000001",
+			filter: bloom.NewFilter(1, 0, 20.9999999769, wire.BloomUpdateAll),
+		},
+		{
+			name:   "fprates less than 1e-9 should be clipped at min",
+			hash:   "02981fa052f0481dbc5868f4fc2166035a10f27a03cfd2de67326471df5bc041",
+			want:   "0566d97a91a91b0000000000000001",
+			filter: bloom.NewFilter(1, 0, 0, wire.BloomUpdateAll),
+		},
+		{
+			name:   "negative fprates should be clipped at min",
+			hash:   "02981fa052f0481dbc5868f4fc2166035a10f27a03cfd2de67326471df5bc041",
+			want:   "0566d97a91a91b0000000000000001",
+			filter: bloom.NewFilter(1, 0, -1, wire.BloomUpdateAll),
+		},
+	}
+
+	for _, test := range tests {
+		// Convert test input to appropriate types.
+		hash, err := chainhash.NewHashFromStr(test.hash)
+		if err != nil {
+			t.Errorf("NewShaHashFromStr unexpected error: %v", err)
+			continue
+		}
+		want, err := hex.DecodeString(test.want)
+		if err != nil {
+			t.Errorf("DecodeString unexpected error: %v\n", err)
+			continue
+		}
+
+		// Add the test hash to the bloom filter and ensure the
+		// filter serializes to the expected bytes.
+		f := test.filter
+		f.AddShaHash(hash)
+		got := bytes.NewBuffer(nil)
+		err = f.MsgFilterLoad().BtcEncode(got, wire.ProtocolVersion)
+		if err != nil {
+			t.Errorf("BtcDecode unexpected error: %v\n", err)
+			continue
+		}
+		if !bytes.Equal(got.Bytes(), want) {
+			t.Errorf("serialized filter mismatch: got %x want %x\n",
+				got.Bytes(), want)
+			continue
+		}
 	}
 }
 


### PR DESCRIPTION
Contains the following upstream commits:

- 52bb44a147d62c23a258d5c68106dbcc00b63dc8
  - Reverted because Travis is already on more recent versions
- e0dbb5b53563bfd27219447c08b68039f9fcca9b
  - Reverted because txsort needs a decred-specific spec
- bdf4400ecafb82f0c121ed5db1ae70639e7f4018
  - Reverted because it has already previously been cherry-picked
- 2c26dd81a59fd671a2218d63ad138a6dd4d693bd
