### PR TITLE
Update for recent chainhash-related API changes.

### DIFF
--- a/base58/base58check.go
+++ b/base58/base58check.go
@@ -20,8 +20,8 @@ var ErrInvalidFormat = errors.New("invalid format: version and/or checksum bytes
 
 // checksum: first four bytes of hash^2
 func checksum(input []byte) (cksum [4]byte) {
-	h := chainhash.HashFuncB(input)
-	h2 := chainhash.HashFuncB(h[:])
+	h := chainhash.HashB(input)
+	h2 := chainhash.HashB(h[:])
 	copy(cksum[:], h2[:4])
 	return
 }

--- a/block.go
+++ b/block.go
@@ -1,5 +1,5 @@
-// Copyright (c) 2013-2014 The btcsuite developers
-// Copyright (c) 2015 The Decred developers
+// Copyright (c) 2013-2016 The btcsuite developers
+// Copyright (c) 2015-2016 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -96,17 +96,15 @@ func (b *Block) BlockHeaderBytes() ([]byte, error) {
 	return serializedBlockHeader, nil
 }
 
-// Sha returns the block identifier hash for the Block.  This is equivalent to
-// calling BlockSha on the underlying wire.MsgBlock, however it caches the
+// Hash returns the block identifier hash for the Block.  This is equivalent to
+// calling BlockHash on the underlying wire.MsgBlock, however it caches the
 // result so subsequent calls are more efficient.
-func (b *Block) Sha() *chainhash.Hash {
+func (b *Block) Hash() *chainhash.Hash {
 	if assertBlockImmutability {
-		hash := b.msgBlock.BlockSha()
+		hash := b.msgBlock.BlockHash()
 		if !hash.IsEqual(&b.hash) {
 			str := fmt.Sprintf("ASSERT: mutated util.block detected, old hash "+
-				"%v, new hash %v",
-				b.hash,
-				hash)
+				"%v, new hash %v", b.hash, hash)
 			panic(str)
 		}
 	}
@@ -240,12 +238,12 @@ func (b *Block) STransactions() []*Tx {
 	return b.sTransactions
 }
 
-// TxSha returns the hash for the requested transaction number in the Block.
+// TxHash returns the hash for the requested transaction number in the Block.
 // The supplied index is 0 based.  That is to say, the first transaction in the
-// block is txNum 0.  This is equivalent to calling TxSha on the underlying
+// block is txNum 0.  This is equivalent to calling TxHash on the underlying
 // wire.MsgTx, however it caches the result so subsequent calls are more
 // efficient.
-func (b *Block) TxSha(txNum int) (*chainhash.Hash, error) {
+func (b *Block) TxHash(txNum int) (*chainhash.Hash, error) {
 	// Attempt to get a wrapped transaction for the specified index.  It
 	// will be created lazily if needed or simply return the cached version
 	// if it has already been generated.
@@ -256,15 +254,15 @@ func (b *Block) TxSha(txNum int) (*chainhash.Hash, error) {
 
 	// Defer to the wrapped transaction which will return the cached hash if
 	// it has already been generated.
-	return tx.Sha(), nil
+	return tx.Hash(), nil
 }
 
-// STxSha returns the hash for the requested stake transaction number in the Block.
-// The supplied index is 0 based.  That is to say, the first transaction in the
-// block is txNum 0.  This is equivalent to calling TxSha on the underlying
-// wire.MsgTx, however it caches the result so subsequent calls are more
-// efficient.
-func (b *Block) STxSha(txNum int) (*chainhash.Hash, error) {
+// STxHash returns the hash for the requested stake transaction number in the
+// Block.  The supplied index is 0 based.  That is to say, the first transaction
+// in the block is txNum 0.  This is equivalent to calling TxHash on the
+// underlying wire.MsgTx, however it caches the result so subsequent calls are
+// more efficient.
+func (b *Block) STxHash(txNum int) (*chainhash.Hash, error) {
 	// Attempt to get a wrapped transaction for the specified index.  It
 	// will be created lazily if needed or simply return the cached version
 	// if it has already been generated.
@@ -275,7 +273,7 @@ func (b *Block) STxSha(txNum int) (*chainhash.Hash, error) {
 
 	// Defer to the wrapped transaction which will return the cached hash if
 	// it has already been generated.
-	return tx.Sha(), nil
+	return tx.Hash(), nil
 }
 
 // TxLoc returns the offsets and lengths of each transaction in a raw block.
@@ -311,7 +309,7 @@ func (b *Block) SetHeight(height int64) {
 // wire.MsgBlock.  See Block.
 func NewBlock(msgBlock *wire.MsgBlock) *Block {
 	return &Block{
-		hash:        msgBlock.BlockSha(),
+		hash:        msgBlock.BlockHash(),
 		msgBlock:    msgBlock,
 		blockHeight: int64(msgBlock.Header.Height),
 	}
@@ -346,7 +344,7 @@ func NewBlockDeepCopyCoinbase(msgBlock *wire.MsgBlock) *Block {
 		blockHeight: int64(msgBlockCopy.Header.Height),
 		msgBlock:    msgBlockCopy,
 	}
-	bl.hash = msgBlock.BlockSha()
+	bl.hash = msgBlock.BlockHash()
 
 	return bl
 }
@@ -376,7 +374,7 @@ func NewBlockDeepCopy(msgBlock *wire.MsgBlock) *Block {
 		blockHeight: int64(msgBlockCopy.Header.Height),
 		msgBlock:    msgBlockCopy,
 	}
-	bl.hash = msgBlock.BlockSha()
+	bl.hash = msgBlock.BlockHash()
 
 	return bl
 }
@@ -405,7 +403,7 @@ func NewBlockFromReader(r io.Reader) (*Block, error) {
 	}
 
 	b := Block{
-		hash:        msgBlock.BlockSha(),
+		hash:        msgBlock.BlockHash(),
 		msgBlock:    &msgBlock,
 		blockHeight: int64(msgBlock.Header.Height),
 	}
@@ -416,7 +414,7 @@ func NewBlockFromReader(r io.Reader) (*Block, error) {
 // an underlying wire.MsgBlock and the serialized bytes for it.  See Block.
 func NewBlockFromBlockAndBytes(msgBlock *wire.MsgBlock, serializedBlock []byte) *Block {
 	return &Block{
-		hash:            msgBlock.BlockSha(),
+		hash:            msgBlock.BlockHash(),
 		msgBlock:        msgBlock,
 		serializedBlock: serializedBlock,
 		blockHeight:     int64(msgBlock.Header.Height),

--- a/block_test.go
+++ b/block_test.go
@@ -1,5 +1,5 @@
-// Copyright (c) 2013-2014 The btcsuite developers
-// Copyright (c) 2015 The Decred developers
+// Copyright (c) 2013-2016 The btcsuite developers
+// Copyright (c) 2015-2016 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -37,23 +37,23 @@ func TestBlock(t *testing.T) {
 	}
 
 	// Hash for block 100,000.
-	wantShaStr := "85457e2420d265386a84fc48aaee4f6dc98bac015dcc8d536ead20e2faf66a9d"
-	wantSha, err := chainhash.NewHashFromStr(wantShaStr)
+	wantHashStr := "85457e2420d265386a84fc48aaee4f6dc98bac015dcc8d536ead20e2faf66a9d"
+	wantHash, err := chainhash.NewHashFromStr(wantHashStr)
 	if err != nil {
-		t.Errorf("NewShaHashFromStr: %v", err)
+		t.Errorf("NewHashFromStr: %v", err)
 	}
 
-	// Request the sha multiple times to test generation and caching.
+	// Request the hash multiple times to test generation and caching.
 	for i := 0; i < 2; i++ {
-		sha := b.Sha()
-		if !sha.IsEqual(wantSha) {
-			t.Errorf("Sha #%d mismatched sha - got %v, want %v", i,
-				sha, wantSha)
+		hash := b.Hash()
+		if !hash.IsEqual(wantHash) {
+			t.Errorf("Hash #%d mismatched hash - got %v, want %v",
+				i, hash, wantHash)
 		}
 	}
 
-	// Shas for the transactions in Block100000.
-	wantTxShas := []string{
+	// Hashes for the transactions in Block100000.
+	wantTxHashes := []string{
 		"1cbd9fe1a143a265cc819ff9d8132a7cbc4ca48eb68c0de39cfdf7ecf42cbbd1",
 		"f3f9bc9473b6fe18d66e3ac2a1a95b6317b280f4e6687a074075b56aebf1eb53",
 		"ba2ed6210a561a4dab34ec8668ad61ec97f126826dae893719dff7383b9d6928",
@@ -63,14 +63,15 @@ func TestBlock(t *testing.T) {
 	// Create a new block to nuke all cached data.
 	b = dcrutil.NewBlock(&Block100000)
 
-	// Request sha for all transactions one at a time via Tx.
-	for i, txSha := range wantTxShas {
-		wantSha, err := chainhash.NewHashFromStr(txSha)
+	// Request hash for all transactions one at a time via Tx.
+	for i, txHash := range wantTxHashes {
+		wantHash, err := chainhash.NewHashFromStr(txHash)
 		if err != nil {
-			t.Errorf("NewShaHashFromStr: %v", err)
+			t.Errorf("NewHashFromStr: %v", err)
 		}
 
-		// Request the sha multiple times to test generation and caching.
+		// Request the hash multiple times to test generation and
+		// caching.
 		for j := 0; j < 2; j++ {
 			tx, err := b.Tx(i)
 			if err != nil {
@@ -78,10 +79,10 @@ func TestBlock(t *testing.T) {
 				continue
 			}
 
-			sha := tx.Sha()
-			if !sha.IsEqual(wantSha) {
-				t.Errorf("Sha #%d mismatched sha - got %v, "+
-					"want %v", j, sha, wantSha)
+			hash := tx.Hash()
+			if !hash.IsEqual(wantHash) {
+				t.Errorf("Hash #%d mismatched hash - got %v, "+
+					"want %v", j, hash, wantHash)
 				continue
 			}
 		}
@@ -96,24 +97,24 @@ func TestBlock(t *testing.T) {
 		transactions := b.Transactions()
 
 		// Ensure we get the expected number of transactions.
-		if len(transactions) != len(wantTxShas) {
+		if len(transactions) != len(wantTxHashes) {
 			t.Errorf("Transactions #%d mismatched number of "+
 				"transactions - got %d, want %d", i,
-				len(transactions), len(wantTxShas))
+				len(transactions), len(wantTxHashes))
 			continue
 		}
 
-		// Ensure all of the shas match.
+		// Ensure all of the hashes match.
 		for j, tx := range transactions {
-			wantSha, err := chainhash.NewHashFromStr(wantTxShas[j])
+			wantHash, err := chainhash.NewHashFromStr(wantTxHashes[j])
 			if err != nil {
-				t.Errorf("NewShaHashFromStr: %v", err)
+				t.Errorf("NewHashFromStr: %v", err)
 			}
 
-			sha := tx.Sha()
-			if !sha.IsEqual(wantSha) {
-				t.Errorf("Transactions #%d mismatched shas - "+
-					"got %v, want %v", j, sha, wantSha)
+			hash := tx.Hash()
+			if !hash.IsEqual(wantHash) {
+				t.Errorf("Transactions #%d mismatched hashes "+
+					"- got %v, want %v", j, hash, wantHash)
 				continue
 			}
 		}
@@ -264,15 +265,15 @@ func TestBlockErrors(t *testing.T) {
 			"got %v, want %v", err, io.EOF)
 	}
 
-	// Ensure TxSha returns expected error on invalid indices.
-	_, err = b.TxSha(-1)
+	// Ensure TxHash returns expected error on invalid indices.
+	_, err = b.TxHash(-1)
 	if _, ok := err.(dcrutil.OutOfRangeError); !ok {
-		t.Errorf("TxSha: wrong error - got: %v <%T>, "+
+		t.Errorf("TxHash: wrong error - got: %v <%T>, "+
 			"want: <%T>", err, err, dcrutil.OutOfRangeError(""))
 	}
-	_, err = b.TxSha(len(Block100000.Transactions) + 1)
+	_, err = b.TxHash(len(Block100000.Transactions) + 1)
 	if _, ok := err.(dcrutil.OutOfRangeError); !ok {
-		t.Errorf("TxSha: wrong error - got: %v <%T>, "+
+		t.Errorf("TxHash: wrong error - got: %v <%T>, "+
 			"want: <%T>", err, err, dcrutil.OutOfRangeError(""))
 	}
 

--- a/bloom/example_test.go
+++ b/bloom/example_test.go
@@ -1,5 +1,5 @@
-// Copyright (c) 2014 The btcsuite developers
-// Copyright (c) 2015 The Decred developers
+// Copyright (c) 2014-2016 The btcsuite developers
+// Copyright (c) 2015-2016 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -35,7 +35,7 @@ func ExampleNewFilter() {
 		fmt.Println(err)
 		return
 	}
-	filter.AddShaHash(txHash)
+	filter.AddHash(txHash)
 
 	// Show that the filter matches.
 	matches := filter.Matches(txHash[:])

--- a/bloom/filter.go
+++ b/bloom/filter.go
@@ -216,10 +216,10 @@ func (bf *Filter) Add(data []byte) {
 	bf.mtx.Unlock()
 }
 
-// AddShaHash adds the passed chainhash.Hash to the Filter.
+// AddHash adds the passed chainhash.Hash to the Filter.
 //
 // This function is safe for concurrent access.
-func (bf *Filter) AddShaHash(hash *chainhash.Hash) {
+func (bf *Filter) AddHash(hash *chainhash.Hash) {
 	bf.mtx.Lock()
 	bf.add(hash[:])
 	bf.mtx.Unlock()
@@ -251,8 +251,7 @@ func (bf *Filter) AddOutPoint(outpoint *wire.OutPoint) {
 // script.
 //
 // This function MUST be called with the filter lock held.
-func (bf *Filter) maybeAddOutpoint(pkScrVer uint16, pkScript []byte,
-	outHash *chainhash.Hash, outIdx uint32, outTree int8) {
+func (bf *Filter) maybeAddOutpoint(pkScrVer uint16, pkScript []byte, outHash *chainhash.Hash, outIdx uint32, outTree int8) {
 	switch bf.msgFilterLoad.Flags {
 	case wire.BloomUpdateAll:
 		outpoint := wire.NewOutPoint(outHash, outIdx, outTree)
@@ -275,7 +274,7 @@ func (bf *Filter) maybeAddOutpoint(pkScrVer uint16, pkScript []byte,
 func (bf *Filter) matchTxAndUpdate(tx *dcrutil.Tx) bool {
 	// Check if the filter matches the hash of the transaction.
 	// This is useful for finding transactions when they appear in a block.
-	matched := bf.matches(tx.Sha()[:])
+	matched := bf.matches(tx.Hash()[:])
 
 	// Check if the filter matches any data elements in the public key
 	// scripts of any of the outputs.  When it does, add the outpoint that
@@ -297,8 +296,8 @@ func (bf *Filter) matchTxAndUpdate(tx *dcrutil.Tx) bool {
 			}
 
 			matched = true
-			bf.maybeAddOutpoint(txOut.Version, txOut.PkScript, tx.Sha(),
-				uint32(i), tx.Tree())
+			bf.maybeAddOutpoint(txOut.Version, txOut.PkScript,
+				tx.Hash(), uint32(i), tx.Tree())
 			break
 		}
 	}

--- a/bloom/filter_test.go
+++ b/bloom/filter_test.go
@@ -130,7 +130,7 @@ func TestFilterFPRange(t *testing.T) {
 		// Convert test input to appropriate types.
 		hash, err := chainhash.NewHashFromStr(test.hash)
 		if err != nil {
-			t.Errorf("NewShaHashFromStr unexpected error: %v", err)
+			t.Errorf("NewHashFromStr unexpected error: %v", err)
 			continue
 		}
 		want, err := hex.DecodeString(test.want)
@@ -142,7 +142,7 @@ func TestFilterFPRange(t *testing.T) {
 		// Add the test hash to the bloom filter and ensure the
 		// filter serializes to the expected bytes.
 		f := test.filter
-		f.AddShaHash(hash)
+		f.AddHash(hash)
 		got := bytes.NewBuffer(nil)
 		err = f.MsgFilterLoad().BtcEncode(got, wire.ProtocolVersion)
 		if err != nil {
@@ -287,64 +287,63 @@ func TestFilterBloomMatch(t *testing.T) {
 
 	f := bloom.NewFilter(10, 0, 0.000001, wire.BloomUpdateAll)
 	inputStr := "50112deb46289119be635b3e486b1e24ae1e7328c228e20e0a753df8621f5e8c"
-	//2a94d783a177460fd00c633ce3011f0e172a721097887ab2de983d741dc8d8f5"
-	sha, err := chainhash.NewHashFromStr(inputStr)
+	hash, err := chainhash.NewHashFromStr(inputStr)
 	if err != nil {
-		t.Errorf("TestFilterBloomMatch NewShaHashFromStr failed: %v\n", err)
+		t.Errorf("TestFilterBloomMatch NewHashFromStr failed: %v\n", err)
 		return
 	}
-	f.AddShaHash(sha)
+	f.AddHash(hash)
 	if !f.MatchTxAndUpdate(tx) {
-		t.Errorf("TestFilterBloomMatch didn't match sha %s", inputStr)
+		t.Errorf("TestFilterBloomMatch didn't match hash %s", inputStr)
 	}
 
 	f = bloom.NewFilter(10, 0, 0.000001, wire.BloomUpdateAll)
 	inputStr = "8c5e1f62f83d750a0ee228c228731eae241e6b483e5b63be19912846eb2d1150"
-	shaBytes, err := hex.DecodeString(inputStr)
+	hashBytes, err := hex.DecodeString(inputStr)
 	if err != nil {
 		t.Errorf("TestFilterBloomMatch DecodeString failed: %v\n", err)
 		return
 	}
-	f.Add(shaBytes)
+	f.Add(hashBytes)
 	if !f.MatchTxAndUpdate(tx) {
-		t.Errorf("TestFilterBloomMatch didn't match sha %s", inputStr)
+		t.Errorf("TestFilterBloomMatch didn't match hash %s", inputStr)
 	}
 
 	f = bloom.NewFilter(10, 0, 0.000001, wire.BloomUpdateAll)
 	inputStr = "30450221008003ce072e4b67f9a98129ac2f58e3de6e06f47a15e248d43" +
 		"75d19dfb527a02d02204ab0a0dfe7c69024ae8e524e01d1c45183efda945a0" +
 		"d411e4e94b69be21efbe601"
-	shaBytes, err = hex.DecodeString(inputStr)
+	hashBytes, err = hex.DecodeString(inputStr)
 	if err != nil {
 		t.Errorf("TestFilterBloomMatch DecodeString failed: %v\n", err)
 		return
 	}
-	f.Add(shaBytes)
+	f.Add(hashBytes)
 	if !f.MatchTxAndUpdate(tx) {
 		t.Errorf("TestFilterBloomMatch didn't match input signature %s", inputStr)
 	}
 
 	f = bloom.NewFilter(10, 0, 0.000001, wire.BloomUpdateAll)
 	inputStr = "0270c906c3ba64ba5eb3943cc012a3b142ef169f066002515bf9ec1bd9b7e27f0d"
-	shaBytes, err = hex.DecodeString(inputStr)
+	hashBytes, err = hex.DecodeString(inputStr)
 	if err != nil {
 		t.Errorf("TestFilterBloomMatch DecodeString failed: %v\n", err)
 		return
 	}
-	f.Add(shaBytes)
+	f.Add(hashBytes)
 	if !f.MatchTxAndUpdate(tx) {
 		t.Errorf("TestFilterBloomMatch didn't match input pubkey %s", inputStr)
 	}
 
 	f = bloom.NewFilter(10, 0, 0.000001, wire.BloomUpdateAll)
 	inputStr = "99678d10a90c8df40e4c9af742aa6ebc7764a60e"
-	shaBytes, err = hex.DecodeString(inputStr)
+	hashBytes, err = hex.DecodeString(inputStr)
 	if err != nil {
 		t.Errorf("TestFilterBloomMatch DecodeString failed: %v\n", err)
 		return
 	}
 
-	f.Add(shaBytes)
+	f.Add(hashBytes)
 	if !f.MatchTxAndUpdate(tx) {
 		t.Errorf("TestFilterBloomMatch didn't match output address %s", inputStr)
 	}
@@ -354,24 +353,24 @@ func TestFilterBloomMatch(t *testing.T) {
 
 	f = bloom.NewFilter(10, 0, 0.000001, wire.BloomUpdateAll)
 	inputStr = "7701528df10cf0c14f9e53925031bd398796c1f9"
-	shaBytes, err = hex.DecodeString(inputStr)
+	hashBytes, err = hex.DecodeString(inputStr)
 	if err != nil {
 		t.Errorf("TestFilterBloomMatch DecodeString failed: %v\n", err)
 		return
 	}
-	f.Add(shaBytes)
+	f.Add(hashBytes)
 	if !f.MatchTxAndUpdate(tx) {
 		t.Errorf("TestFilterBloomMatch didn't match output address %s", inputStr)
 	}
 
 	f = bloom.NewFilter(10, 0, 0.000001, wire.BloomUpdateAll)
 	inputStr = "759a520aaa1427ccd9deeca4a1f9c47fd350a6f4e94bc9104cba1624cabbfba4"
-	sha, err = chainhash.NewHashFromStr(inputStr)
+	hash, err = chainhash.NewHashFromStr(inputStr)
 	if err != nil {
-		t.Errorf("TestFilterBloomMatch NewShaHashFromStr failed: %v\n", err)
+		t.Errorf("TestFilterBloomMatch NewHashFromStr failed: %v\n", err)
 		return
 	}
-	outpoint := wire.NewOutPoint(sha, 0, wire.TxTreeRegular)
+	outpoint := wire.NewOutPoint(hash, 0, wire.TxTreeRegular)
 	f.AddOutPoint(outpoint)
 	if !f.MatchTxAndUpdate(tx) {
 		t.Errorf("TestFilterBloomMatch didn't match outpoint %s", inputStr)
@@ -379,37 +378,37 @@ func TestFilterBloomMatch(t *testing.T) {
 	// XXX unchanged from btcd
 	f = bloom.NewFilter(10, 0, 0.000001, wire.BloomUpdateAll)
 	inputStr = "00000009e784f32f62ef849763d4f45b98e07ba658647343b915ff832b110436"
-	sha, err = chainhash.NewHashFromStr(inputStr)
+	hash, err = chainhash.NewHashFromStr(inputStr)
 	if err != nil {
-		t.Errorf("TestFilterBloomMatch NewShaHashFromStr failed: %v\n", err)
+		t.Errorf("TestFilterBloomMatch NewHashFromStr failed: %v\n", err)
 		return
 	}
-	f.AddShaHash(sha)
+	f.AddHash(hash)
 	if f.MatchTxAndUpdate(tx) {
-		t.Errorf("TestFilterBloomMatch matched sha %s", inputStr)
+		t.Errorf("TestFilterBloomMatch matched hash %s", inputStr)
 	}
 
 	// XXX unchanged from btcd
 	f = bloom.NewFilter(10, 0, 0.000001, wire.BloomUpdateAll)
 	inputStr = "0000006d2965547608b9e15d9032a7b9d64fa431"
-	shaBytes, err = hex.DecodeString(inputStr)
+	hashBytes, err = hex.DecodeString(inputStr)
 	if err != nil {
 		t.Errorf("TestFilterBloomMatch DecodeString failed: %v\n", err)
 		return
 	}
-	f.Add(shaBytes)
+	f.Add(hashBytes)
 	if f.MatchTxAndUpdate(tx) {
 		t.Errorf("TestFilterBloomMatch matched address %s", inputStr)
 	}
 
 	f = bloom.NewFilter(10, 0, 0.000001, wire.BloomUpdateAll)
 	inputStr = "759a520aaa1427ccd9deeca4a1f9c47fd350a6f4e94bc9104cba1624cabbfba4"
-	sha, err = chainhash.NewHashFromStr(inputStr)
+	hash, err = chainhash.NewHashFromStr(inputStr)
 	if err != nil {
-		t.Errorf("TestFilterBloomMatch NewShaHashFromStr failed: %v\n", err)
+		t.Errorf("TestFilterBloomMatch NewHashFromStr failed: %v\n", err)
 		return
 	}
-	outpoint = wire.NewOutPoint(sha, 1, wire.TxTreeRegular)
+	outpoint = wire.NewOutPoint(hash, 1, wire.TxTreeRegular)
 	f.AddOutPoint(outpoint)
 	if f.MatchTxAndUpdate(tx) {
 		t.Errorf("TestFilterBloomMatch matched outpoint %s", inputStr)
@@ -418,12 +417,12 @@ func TestFilterBloomMatch(t *testing.T) {
 	// XXX unchanged from btcd
 	f = bloom.NewFilter(10, 0, 0.000001, wire.BloomUpdateAll)
 	inputStr = "000000d70786e899529d71dbeba91ba216982fb6ba58f3bdaab65e73b7e9260b"
-	sha, err = chainhash.NewHashFromStr(inputStr)
+	hash, err = chainhash.NewHashFromStr(inputStr)
 	if err != nil {
-		t.Errorf("TestFilterBloomMatch NewShaHashFromStr failed: %v\n", err)
+		t.Errorf("TestFilterBloomMatch NewHashFromStr failed: %v\n", err)
 		return
 	}
-	outpoint = wire.NewOutPoint(sha, 0, wire.TxTreeRegular)
+	outpoint = wire.NewOutPoint(hash, 0, wire.TxTreeRegular)
 	f.AddOutPoint(outpoint)
 	if f.MatchTxAndUpdate(tx) {
 		t.Errorf("TestFilterBloomMatch matched outpoint %s", inputStr)
@@ -452,12 +451,12 @@ func TestFilterInsertUpdateNone(t *testing.T) {
 	f.Add(inputBytes)
 
 	inputStr = "147caa76786596590baa4e98f5d9f48b86c7765e489f7a6ff3360fe5c674360b"
-	sha, err := chainhash.NewHashFromStr(inputStr)
+	hash, err := chainhash.NewHashFromStr(inputStr)
 	if err != nil {
-		t.Errorf("TestFilterInsertUpdateNone NewShaHashFromStr failed: %v", err)
+		t.Errorf("TestFilterInsertUpdateNone NewHashFromStr failed: %v", err)
 		return
 	}
-	outpoint := wire.NewOutPoint(sha, 0, wire.TxTreeRegular)
+	outpoint := wire.NewOutPoint(hash, 0, wire.TxTreeRegular)
 
 	if f.MatchesOutPoint(outpoint) {
 		t.Errorf("TestFilterInsertUpdateNone matched outpoint %s", inputStr)
@@ -465,12 +464,12 @@ func TestFilterInsertUpdateNone(t *testing.T) {
 	}
 
 	inputStr = "02981fa052f0481dbc5868f4fc2166035a10f27a03cfd2de67326471df5bc041"
-	sha, err = chainhash.NewHashFromStr(inputStr)
+	hash, err = chainhash.NewHashFromStr(inputStr)
 	if err != nil {
-		t.Errorf("TestFilterInsertUpdateNone NewShaHashFromStr failed: %v", err)
+		t.Errorf("TestFilterInsertUpdateNone NewHashFromStr failed: %v", err)
 		return
 	}
-	outpoint = wire.NewOutPoint(sha, 0, wire.TxTreeRegular)
+	outpoint = wire.NewOutPoint(hash, 0, wire.TxTreeRegular)
 
 	if f.MatchesOutPoint(outpoint) {
 		t.Errorf("TestFilterInsertUpdateNone matched outpoint %s", inputStr)
@@ -600,12 +599,12 @@ func TestFilterInsertP2PubKeyOnly(t *testing.T) {
 
 	// We should match the generation pubkey
 	inputStr = "8199f30ccc006056ed79cf0a3cd0b67a195ffd46903d42adc7babe2ed2f2e371"
-	sha, err := chainhash.NewHashFromStr(inputStr)
+	hash, err := chainhash.NewHashFromStr(inputStr)
 	if err != nil {
-		t.Errorf("TestMerkleBlockP2PubKeyOnly NewShaHashFromStr failed: %v", err)
+		t.Errorf("TestMerkleBlockP2PubKeyOnly NewHashFromStr failed: %v", err)
 		return
 	}
-	outpoint := wire.NewOutPoint(sha, 0, wire.TxTreeRegular)
+	outpoint := wire.NewOutPoint(hash, 0, wire.TxTreeRegular)
 	if !f.MatchesOutPoint(outpoint) {
 		t.Errorf("TestMerkleBlockP2PubKeyOnly didn't match the generation "+
 			"outpoint %s", inputStr)
@@ -614,12 +613,12 @@ func TestFilterInsertP2PubKeyOnly(t *testing.T) {
 
 	// We should not match the 4th transaction, which is not p2pk
 	inputStr = "d7314aaf54253c651e8258c7d22c574af8804611f0dcea79fd9a47f4565d85ad"
-	sha, err = chainhash.NewHashFromStr(inputStr)
+	hash, err = chainhash.NewHashFromStr(inputStr)
 	if err != nil {
-		t.Errorf("TestMerkleBlockP2PubKeyOnly NewShaHashFromStr failed: %v", err)
+		t.Errorf("TestMerkleBlockP2PubKeyOnly NewHashFromStr failed: %v", err)
 		return
 	}
-	outpoint = wire.NewOutPoint(sha, 0, wire.TxTreeRegular)
+	outpoint = wire.NewOutPoint(hash, 0, wire.TxTreeRegular)
 	if f.MatchesOutPoint(outpoint) {
 		t.Errorf("TestMerkleBlockP2PubKeyOnly matched outpoint %s", inputStr)
 		return

--- a/bloom/merkleblock.go
+++ b/bloom/merkleblock.go
@@ -1,5 +1,5 @@
-// Copyright (c) 2013, 2014 The btcsuite developers
-// Copyright (c) 2015 The Decred developers
+// Copyright (c) 2013-2016 The btcsuite developers
+// Copyright (c) 2015-2016 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -97,7 +97,7 @@ func NewMerkleBlock(block *dcrutil.Block, filter *Filter) (*wire.MsgMerkleBlock,
 		} else {
 			mBlock.matchedBits = append(mBlock.matchedBits, 0x00)
 		}
-		mBlock.allHashes = append(mBlock.allHashes, tx.Sha())
+		mBlock.allHashes = append(mBlock.allHashes, tx.Hash())
 	}
 
 	// Calculate the number of merkle branches (height) in the tree.
@@ -116,8 +116,8 @@ func NewMerkleBlock(block *dcrutil.Block, filter *Filter) (*wire.MsgMerkleBlock,
 		Hashes:       make([]*chainhash.Hash, 0, len(mBlock.finalHashes)),
 		Flags:        make([]byte, (len(mBlock.bits)+7)/8),
 	}
-	for _, sha := range mBlock.finalHashes {
-		msgMerkleBlock.AddTxHash(sha)
+	for _, hash := range mBlock.finalHashes {
+		msgMerkleBlock.AddTxHash(hash)
 	}
 	for i := uint32(0); i < uint32(len(mBlock.bits)); i++ {
 		msgMerkleBlock.Flags[i/8] |= mBlock.bits[i] << (i % 8)

--- a/bloom/merkleblock_test.go
+++ b/bloom/merkleblock_test.go
@@ -1,5 +1,5 @@
-// Copyright (c) 2013, 2014 The btcsuite developers
-// Copyright (c) 2015 The Decred developers
+// Copyright (c) 2013-2016 The btcsuite developers
+// Copyright (c) 2015-2016 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -32,13 +32,13 @@ func TestMerkleBlock3(t *testing.T) {
 	f := bloom.NewFilter(10, 0, 0.000001, wire.BloomUpdateAll)
 
 	inputStr := "4986147957b25177d345104d5b6c18042b3600ee8bc551065cfaaca0dd46fd33"
-	sha, err := chainhash.NewHashFromStr(inputStr)
+	hash, err := chainhash.NewHashFromStr(inputStr)
 	if err != nil {
-		t.Errorf("TestMerkleBlock3 NewShaHashFromStr failed: %v", err)
+		t.Errorf("TestMerkleBlock3 NewHashFromStr failed: %v", err)
 		return
 	}
 
-	f.AddShaHash(sha)
+	f.AddHash(hash)
 
 	mBlock, _ := bloom.NewMerkleBlock(blk, f)
 	wantStr := "0100000073cf056852529ffadc50b49589218795adc4d3f24170950d49f201000000000033fd46dda0acfa5c0651c58bee00362b04186c5b4d1045d37751b25779148649000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000ffff011b00c2eb0b00000000000100007e0100006614b956bee4fc44442bf144050552b3010000000000000000000000000000000000000000000000000000000100000001d0f51e5a4978d736eb3d4a8d615bee74943756b4745d29b27ab2943bc1307cc800000000000100"

--- a/coinset/coins.go
+++ b/coinset/coins.go
@@ -1,5 +1,5 @@
-// Copyright (c) 2014-2015 The btcsuite developers
-// Copyright (c) 2015 The Decred developers
+// Copyright (c) 2014-2016 The btcsuite developers
+// Copyright (c) 2015-2016 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -361,7 +361,7 @@ var _ Coin = &SimpleCoin{}
 
 // Hash returns the hash value of the transaction on which the Coin is an output
 func (c *SimpleCoin) Hash() *chainhash.Hash {
-	return c.Tx.Sha()
+	return c.Tx.Hash()
 }
 
 // Index returns the index of the output on the transaction which the Coin represents

--- a/coinset/coins_test.go
+++ b/coinset/coins_test.go
@@ -1,5 +1,5 @@
-// Copyright (c) 2014-2015 The btcsuite developers
-// Copyright (c) 2015 The Decred developers
+// Copyright (c) 2014-2016 The btcsuite developers
+// Copyright (c) 2015-2016 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 

--- a/hash160.go
+++ b/hash160.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2014 The btcsuite developers
-// Copyright (c) 2015 The Decred developers
+// Copyright (c) 2015-2016 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -20,5 +20,5 @@ func calcHash(buf []byte, hasher hash.Hash) []byte {
 
 // Hash160 calculates the hash ripemd160(hash256(b)).
 func Hash160(buf []byte) []byte {
-	return calcHash(chainhash.HashFuncB(buf), ripemd160.New())
+	return calcHash(chainhash.HashB(buf), ripemd160.New())
 }

--- a/hdkeychain/extendedkey.go
+++ b/hdkeychain/extendedkey.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2014 The btcsuite developers
+// Copyright (c) 2014-2016 The btcsuite developers
 // Copyright (c) 2015-2016 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
@@ -397,7 +397,7 @@ func (k *ExtendedKey) String() (string, error) {
 		serializedBytes = append(serializedBytes, k.pubKeyBytes()...)
 	}
 
-	checkSum := chainhash.HashFuncB(chainhash.HashFuncB(serializedBytes))[:4]
+	checkSum := chainhash.HashB(chainhash.HashB(serializedBytes))[:4]
 	serializedBytes = append(serializedBytes, checkSum...)
 	return base58.Encode(serializedBytes), nil
 }
@@ -499,7 +499,7 @@ func NewKeyFromString(key string) (*ExtendedKey, error) {
 	// Split the payload and checksum up and ensure the checksum matches.
 	payload := decoded[:len(decoded)-4]
 	checkSum := decoded[len(decoded)-4:]
-	expectedCheckSum := chainhash.HashFuncB(chainhash.HashFuncB(payload))[:4]
+	expectedCheckSum := chainhash.HashB(chainhash.HashB(payload))[:4]
 	if !bytes.Equal(checkSum, expectedCheckSum) {
 		return nil, ErrBadChecksum
 	}

--- a/tx.go
+++ b/tx.go
@@ -1,5 +1,5 @@
-// Copyright (c) 2013-2014 The btcsuite developers
-// Copyright (c) 2015 The Decred developers
+// Copyright (c) 2013-2016 The btcsuite developers
+// Copyright (c) 2015-2016 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -28,10 +28,10 @@ const TxIndexUnknown = -1
 // first access so subsequent accesses don't have to repeat the relatively
 // expensive hashing operations.
 type Tx struct {
-	hash    chainhash.Hash
-	msgTx   *wire.MsgTx // Underlying MsgTx
-	txTree  int8        // Indicates which tx tree the tx is found in
-	txIndex int         // Position within a block or TxIndexUnknown
+	hash    chainhash.Hash // Cached transaction hash
+	msgTx   *wire.MsgTx    // Underlying MsgTx
+	txTree  int8           // Indicates which tx tree the tx is found in
+	txIndex int            // Position within a block or TxIndexUnknown
 }
 
 // MsgTx returns the underlying wire.MsgTx for the transaction.
@@ -40,12 +40,12 @@ func (t *Tx) MsgTx() *wire.MsgTx {
 	return t.msgTx
 }
 
-// Sha returns the hash of the transaction.  This is equivalent to
-// calling TxSha on the underlying wire.MsgTx, however it caches the
+// Hash returns the hash of the transaction.  This is equivalent to
+// calling TxHash on the underlying wire.MsgTx, however it caches the
 // result so subsequent calls are more efficient.
-func (t *Tx) Sha() *chainhash.Hash {
+func (t *Tx) Hash() *chainhash.Hash {
 	if assertTransactionImmutability {
-		hash := t.msgTx.TxSha()
+		hash := t.msgTx.TxHash()
 		if !hash.IsEqual(&t.hash) {
 			str := fmt.Sprintf("ASSERT: mutated util.tx detected, old hash %v, "+
 				"new hash %v",
@@ -83,7 +83,7 @@ func (t *Tx) SetTree(tree int8) {
 // wire.MsgTx.  See Tx.
 func NewTx(msgTx *wire.MsgTx) *Tx {
 	return &Tx{
-		hash:    msgTx.TxSha(),
+		hash:    msgTx.TxHash(),
 		msgTx:   msgTx,
 		txTree:  wire.TxTreeUnknown,
 		txIndex: TxIndexUnknown,
@@ -139,7 +139,7 @@ func NewTxDeep(msgTx *wire.MsgTx) *Tx {
 	}
 
 	return &Tx{
-		hash:    mtx.TxSha(),
+		hash:    mtx.TxHash(),
 		msgTx:   mtx,
 		txTree:  wire.TxTreeUnknown,
 		txIndex: TxIndexUnknown,
@@ -188,7 +188,7 @@ func NewTxDeepTxIns(msgTx *wire.MsgTx) *Tx {
 	}
 
 	return &Tx{
-		hash:    msgTx.TxSha(),
+		hash:    msgTx.TxHash(),
 		msgTx:   msgTx,
 		txTree:  wire.TxTreeUnknown,
 		txIndex: TxIndexUnknown,
@@ -213,7 +213,7 @@ func NewTxFromReaderLegacy(r io.Reader) (*Tx, error) {
 	}
 
 	t := Tx{
-		hash:    msgTx.TxSha(),
+		hash:    msgTx.TxHash(),
 		msgTx:   &msgTx,
 		txTree:  wire.TxTreeUnknown,
 		txIndex: TxIndexUnknown,
@@ -240,7 +240,7 @@ func NewTxFromReader(r io.Reader) (*Tx, error) {
 	}
 
 	t := Tx{
-		hash:    msgTx.TxSha(),
+		hash:    msgTx.TxHash(),
 		msgTx:   &msgTx,
 		txTree:  wire.TxTreeUnknown,
 		txIndex: TxIndexUnknown,

--- a/tx_test.go
+++ b/tx_test.go
@@ -1,5 +1,5 @@
-// Copyright (c) 2013-2014 The btcsuite developers
-// Copyright (c) 2015 The Decred developers
+// Copyright (c) 2013-2016 The btcsuite developers
+// Copyright (c) 2015-2016 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -60,18 +60,18 @@ func TestTx(t *testing.T) {
 	}
 
 	// Hash for block 100,000 transaction 0.
-	wantShaStr := "1cbd9fe1a143a265cc819ff9d8132a7cbc4ca48eb68c0de39cfdf7ecf42cbbd1"
-	wantSha, err := chainhash.NewHashFromStr(wantShaStr)
+	wantHashStr := "1cbd9fe1a143a265cc819ff9d8132a7cbc4ca48eb68c0de39cfdf7ecf42cbbd1"
+	wantHash, err := chainhash.NewHashFromStr(wantHashStr)
 	if err != nil {
-		t.Errorf("NewShaHashFromStr: %v", err)
+		t.Errorf("NewHashFromStr: %v", err)
 	}
 
-	// Request the sha multiple times to test generation and caching.
+	// Request the hash multiple times to test generation and caching.
 	for i := 0; i < 2; i++ {
-		sha := tx.Sha()
-		if !sha.IsEqual(wantSha) {
-			t.Errorf("Sha #%d mismatched sha - got %v, want %v", i,
-				sha, wantSha)
+		hash := tx.Hash()
+		if !hash.IsEqual(wantHash) {
+			t.Errorf("Hash #%d mismatched hash - got %v, want %v", i,
+				hash, wantHash)
 		}
 	}
 }

--- a/wif.go
+++ b/wif.go
@@ -1,5 +1,5 @@
-// Copyright (c) 2013, 2014 The btcsuite developers
-// Copyright (c) 2015 The Decred developers
+// Copyright (c) 2013-2016 The btcsuite developers
+// Copyright (c) 2015-2016 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -84,7 +84,7 @@ func DecodeWIF(wif string) (*WIF, error) {
 	// Checksum is first four bytes of hash of the identifier byte
 	// and privKey.  Verify this matches the final 4 bytes of the decoded
 	// private key.
-	cksum := chainhash.HashFuncB(decoded[:decodedLen-4])
+	cksum := chainhash.HashB(decoded[:decodedLen-4])
 	if !bytes.Equal(cksum[:4], decoded[decodedLen-4:]) {
 		return nil, ErrChecksumMismatch
 	}
@@ -125,7 +125,7 @@ func (w *WIF) String() string {
 	a = append(a, byte(w.ecType))
 	a = append(a, w.PrivKey.Serialize()...)
 
-	cksum := chainhash.HashFuncB(a)
+	cksum := chainhash.HashB(a)
 	a = append(a, cksum[:4]...)
 	return base58.Encode(a)
 }


### PR DESCRIPTION
**This requires decred/dcrd#467**.

Upstream commit 22c91fa80a5e90e3feda26cf6d43adc249306188.

Also, in keeping with the spirit of the upstream commits, the merge commit also renames all other instances of variables and function names that have `sha` in their names to include `hash` instead (all variants).  This is particularly beneficial for Decred because decred uses `blake` for hashing instead of `sha`.
