### PR TITLE
Remove the defaultNet param for DecodeAddress

### DIFF
--- a/address.go
+++ b/address.go
@@ -214,17 +214,6 @@ func detectNetworkForAddress(addr string) (*chaincfg.Params, error) {
 	return nil, fmt.Errorf("unknown network type in string encoded address")
 }
 
-// DecodeNetworkAddress decodes the string encoding of an address and returns
-// the Address if addr is a valid encoding for a known address type. The network
-// type is automatically detected.
-//
-// The network the address is associated with is extracted if possible.
-// When the address does not encode the network, such as in the case of a raw
-// public key, the address will be associated with the passed defaultNet.
-func DecodeNetworkAddress(addr string) (Address, error) {
-	return DecodeAddress(addr)
-}
-
 // AddressPubKeyHash is an Address for a pay-to-pubkey-hash (P2PKH)
 // transaction.
 type AddressPubKeyHash struct {

--- a/address_test.go
+++ b/address_test.go
@@ -115,11 +115,6 @@ func TestAddresses(t *testing.T) {
 			valid: false,
 			net:   &chaincfg.TestNet2Params,
 		},
-		{
-			name:  "p2pkh no default net",
-			addr:  "TsmWaPM77WSyA3aiQ2Q1KnwGDVWvEkhipBc",
-			valid: false,
-		},
 
 		// Positive P2SH tests.
 		{
@@ -479,7 +474,7 @@ func TestAddresses(t *testing.T) {
 
 	for _, test := range tests {
 		// Decode addr and compare error against valid.
-		decoded, err := dcrutil.DecodeAddress(test.addr, test.net)
+		decoded, err := dcrutil.DecodeAddress(test.addr)
 		if (err == nil) != test.valid {
 			t.Errorf("%v: decoding test failed: %v", test.name, err)
 			return


### PR DESCRIPTION
~~NOTE: This PR contains a temporary glide redirect to https://github.com/dnldd/dcrd/tree/decodeaddress.  This will need to be removed before merging~~