### PR TITLE
tx: Update for wire serialization type API change.

### DIFF
--- a/block_test.go
+++ b/block_test.go
@@ -327,6 +327,7 @@ var Block100000 = wire.MsgBlock{
 	},
 	Transactions: []*wire.MsgTx{
 		{
+			SerType: wire.TxSerializeFull,
 			Version: 1,
 			TxIn: []*wire.TxIn{
 				{
@@ -361,6 +362,7 @@ var Block100000 = wire.MsgBlock{
 			LockTime: 0,
 		},
 		{
+			SerType: wire.TxSerializeFull,
 			Version: 1,
 			TxIn: []*wire.TxIn{
 				{
@@ -430,6 +432,7 @@ var Block100000 = wire.MsgBlock{
 			LockTime: 0,
 		},
 		{
+			SerType: wire.TxSerializeFull,
 			Version: 1,
 			TxIn: []*wire.TxIn{
 				{
@@ -498,6 +501,7 @@ var Block100000 = wire.MsgBlock{
 			LockTime: 0,
 		},
 		{
+			SerType: wire.TxSerializeFull,
 			Version: 1,
 			TxIn: []*wire.TxIn{
 				{

--- a/tx.go
+++ b/tx.go
@@ -131,6 +131,7 @@ func NewTxDeep(msgTx *wire.MsgTx) *Tx {
 
 	mtx := &wire.MsgTx{
 		CachedHash: nil,
+		SerType:    msgTx.SerType,
 		Version:    msgTx.Version,
 		TxIn:       txIns,
 		TxOut:      txOuts,


### PR DESCRIPTION
~**NOTE: This contains an override in `glide.yaml` for decred/dcrd#798 that needs to be removed before this is merged**~